### PR TITLE
Add theme-color

### DIFF
--- a/brneni.html
+++ b/brneni.html
@@ -17,6 +17,12 @@
     <title>Brnění – Start@FIT 2023</title>
 
     <link rel="icon" type="image/x-icon" href="img/favicon.png" />
+    <!-- Chrome, Firefox OS and Opera -->
+    <meta name="theme-color" content="#226495" />
+    <!-- Windows Phone -->
+    <meta name="msapplication-navbutton-color" content="#226495" />
+    <!-- iOS Safari -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="#226495" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/ctvrtek.html
+++ b/ctvrtek.html
@@ -17,6 +17,12 @@
     <title>Čtvrtek – Start@FIT 2023</title>
 
     <link rel="icon" type="image/x-icon" href="img/favicon.png" />
+    <!-- Chrome, Firefox OS and Opera -->
+    <meta name="theme-color" content="#226495" />
+    <!-- Windows Phone -->
+    <meta name="msapplication-navbutton-color" content="#226495" />
+    <!-- iOS Safari -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="#226495" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/index.html
+++ b/index.html
@@ -17,6 +17,12 @@
     <title>Start@FIT 2023</title>
 
     <link rel="icon" type="image/x-icon" href="img/favicon.png" />
+    <!-- Chrome, Firefox OS and Opera -->
+    <meta name="theme-color" content="#226495" />
+    <!-- Windows Phone -->
+    <meta name="msapplication-navbutton-color" content="#226495" />
+    <!-- iOS Safari -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="#226495" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/nedele.html
+++ b/nedele.html
@@ -17,6 +17,12 @@
     <title>Neděle – Start@FIT 2023</title>
 
     <link rel="icon" type="image/x-icon" href="img/favicon.png" />
+    <!-- Chrome, Firefox OS and Opera -->
+    <meta name="theme-color" content="#226495" />
+    <!-- Windows Phone -->
+    <meta name="msapplication-navbutton-color" content="#226495" />
+    <!-- iOS Safari -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="#226495" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/patek.html
+++ b/patek.html
@@ -17,6 +17,12 @@
     <title>Pátek – Start@FIT 2023</title>
 
     <link rel="icon" type="image/x-icon" href="img/favicon.png" />
+    <!-- Chrome, Firefox OS and Opera -->
+    <meta name="theme-color" content="#226495" />
+    <!-- Windows Phone -->
+    <meta name="msapplication-navbutton-color" content="#226495" />
+    <!-- iOS Safari -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="#226495" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/photos.html
+++ b/photos.html
@@ -17,6 +17,12 @@
     <title>Z minulých let – Start@FIT 2023</title>
 
     <link rel="icon" type="image/x-icon" href="img/favicon.png" />
+    <!-- Chrome, Firefox OS and Opera -->
+    <meta name="theme-color" content="#226495" />
+    <!-- Windows Phone -->
+    <meta name="msapplication-navbutton-color" content="#226495" />
+    <!-- iOS Safari -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="#226495" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/start-fest.html
+++ b/start-fest.html
@@ -17,6 +17,12 @@
     <title>start-fest 2023</title>
 
     <link rel="icon" type="image/x-icon" href="img/favicon.png" />
+    <!-- Chrome, Firefox OS and Opera -->
+    <meta name="theme-color" content="#226495" />
+    <!-- Windows Phone -->
+    <meta name="msapplication-navbutton-color" content="#226495" />
+    <!-- iOS Safari -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="#226495" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
Přidal jsem (snad) hezčí hlavičku pro Google Chrome a další prohlížeče více o theme-color [zde](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color).

Mělo by to fungovat primárně ve světlém režim, předpokládám, že v nočním režimu máme smůlu.

Proč to vůbec chci? Viděl jsem dneska někoho v Kachně, jak má ty krásné stránky otevřené v Chromu na mobilu a svítí mu tam ten hnusný bílý horní panel s url do obličeje. 😄 